### PR TITLE
Ensure that filenames are valid as PouchDB attachments.

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -1,0 +1,38 @@
+package fb
+
+import "testing"
+
+type escapeFilenameTest struct {
+	Filename string
+	Expected string
+}
+
+func TestEscapeFilename(t *testing.T) {
+	tests := []escapeFilenameTest{
+		escapeFilenameTest{
+			Filename: "foobar.jpg",
+			Expected: "foobar.jpg",
+		},
+		escapeFilenameTest{
+			Filename: "_foobar.jpg",
+			Expected: "%5Ffoobar.jpg",
+		},
+		escapeFilenameTest{
+			Filename: "^영상.jpg",
+			Expected: "%5E%EC%98%81%EC%83%81.jpg",
+		},
+	}
+	for _, test := range tests {
+		result := escapeFilename(test.Filename)
+		if result != test.Expected {
+			t.Errorf("Escape filename '%s' failed.\n\tExpected: %s\n\t  Actual: %s\n", test.Filename, test.Expected, result)
+		}
+		unResult, err := unescapeFilename(result)
+		if err != nil {
+			t.Errorf("Unexpected error unescaping filename '%s': %s\n", unResult, err)
+		}
+		if unResult != test.Filename {
+			t.Errorf("Unescape filename '%s' failed.\n\tExpected: %s\n\t  Actual: %s\n", result, test.Filename, unResult)
+		}
+	}
+}

--- a/test/note_test.go
+++ b/test/note_test.go
@@ -24,11 +24,21 @@ var frozenNote = []byte(`
         },
         {
             "files": [
-                "foo.mp3"
+                "_weirdname.txt",
+                "foo.mp3",
+                "영상.jpg"
             ]
         }
     ],
     "_attachments": {
+        "%EC%98%81%EC%83%81.jpg": {
+            "content_type": "audio/mpeg",
+            "data": "YSBLb3JlYW4gZmlsZW5hbWU="
+        },
+        "%5Fweirdname.txt": {
+            "content_type": "audio/mpeg",
+            "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
+        },
         "foo.mp3": {
             "content_type": "audio/mpeg",
             "data": "bm90IGEgcmVhbCBNUDM="
@@ -61,6 +71,12 @@ func TestNote(t *testing.T) {
 
 	err = fv2.AddFile("foo.mp3", "audio/mpeg", []byte("not a real MP3"))
 	require.Nil(err, "Error attaching audio file: %s", err)
+
+	err = fv2.AddFile("_weirdname.txt", "audio/mpeg", []byte("a file with a strange name"))
+	require.Nil(err, "Error attaching strangely named file: %s", err)
+
+	err = fv2.AddFile("영상.jpg", "audio/mpeg", []byte("a Korean filename"))
+	require.Nil(err, "Error attaching strangely named file: %s", err)
 
 	require.MarshalsToJSON(frozenNote, n, "Create Note")
 
@@ -120,11 +136,21 @@ var frozenMergedNote = []byte(`
         },
         {
             "files": [
-                "foo.mp3"
+                "_weirdname.txt",
+                "foo.mp3",
+                "영상.jpg"
             ]
         }
     ],
     "_attachments": {
+        "%5Fweirdname.txt": {
+            "content_type": "audio/mpeg",
+            "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
+        },
+        "%EC%98%81%EC%83%81.jpg": {
+            "content_type": "audio/mpeg",
+            "data": "YSBLb3JlYW4gZmlsZW5hbWU="
+        },
         "foo.mp3": {
             "content_type": "audio/mpeg",
             "data": "bm90IGEgcmVhbCBNUDM="

--- a/test/package_test.go
+++ b/test/package_test.go
@@ -58,11 +58,21 @@ var frozenPackage = []byte(`
                 },
                 {
                     "files": [
-                        "foo.mp3"
+                        "_weirdname.txt",
+                        "foo.mp3",
+                        "영상.jpg"
                     ]
                 }
             ],
             "_attachments": {
+                "%5Fweirdname.txt": {
+                    "content_type": "audio/mpeg",
+                    "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
+                },
+                "%EC%98%81%EC%83%81.jpg": {
+                    "content_type": "audio/mpeg",
+                    "data": "YSBLb3JlYW4gZmlsZW5hbWU="
+                },
                 "foo.mp3": {
                     "content_type": "audio/mpeg",
                     "data": "bm90IGEgcmVhbCBNUDM="
@@ -132,7 +142,7 @@ var frozenPackage = []byte(`
                 }
             ],
             "_attachments": {
-                "$main.css": {
+                "%24main.css": {
                     "content_type": "text/css",
                     "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
                 },

--- a/test/theme_test.go
+++ b/test/theme_test.go
@@ -67,7 +67,7 @@ var frozenTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "$main.css": {
+        "%24main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }
@@ -174,7 +174,7 @@ var frozenExistingTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "$main.css": {
+        "%24main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }
@@ -245,7 +245,7 @@ var frozenMergedTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "$main.css": {
+        "%24main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }


### PR DESCRIPTION
PouchDB prohibits filenames that begin with a _, so we now escape this.  And
while I was at it, I escape everything to URL encoding, which should make it
easier and safer to support non-ASCII filenames.