### PR TITLE
Don't use URL escaping for attachment filenames.

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -15,11 +15,19 @@ func TestEscapeFilename(t *testing.T) {
 		},
 		escapeFilenameTest{
 			Filename: "_foobar.jpg",
-			Expected: "%5Ffoobar.jpg",
+			Expected: "^_foobar.jpg",
 		},
 		escapeFilenameTest{
-			Filename: "^영상.jpg",
-			Expected: "%5E%EC%98%81%EC%83%81.jpg",
+			Filename: "^foobar.jpg",
+			Expected: "^^foobar.jpg",
+		},
+		escapeFilenameTest{
+			Filename: "foo^bar_baz.jpg",
+			Expected: "foo^bar_baz.jpg",
+		},
+		escapeFilenameTest{
+			Filename: "영상.jpg",
+			Expected: "영상.jpg",
 		},
 	}
 	for _, test := range tests {

--- a/test/note_test.go
+++ b/test/note_test.go
@@ -31,11 +31,11 @@ var frozenNote = []byte(`
         }
     ],
     "_attachments": {
-        "%EC%98%81%EC%83%81.jpg": {
+        "영상.jpg": {
             "content_type": "audio/mpeg",
             "data": "YSBLb3JlYW4gZmlsZW5hbWU="
         },
-        "%5Fweirdname.txt": {
+        "^_weirdname.txt": {
             "content_type": "audio/mpeg",
             "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
         },
@@ -143,11 +143,11 @@ var frozenMergedNote = []byte(`
         }
     ],
     "_attachments": {
-        "%5Fweirdname.txt": {
+        "^_weirdname.txt": {
             "content_type": "audio/mpeg",
             "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
         },
-        "%EC%98%81%EC%83%81.jpg": {
+        "영상.jpg": {
             "content_type": "audio/mpeg",
             "data": "YSBLb3JlYW4gZmlsZW5hbWU="
         },

--- a/test/package_test.go
+++ b/test/package_test.go
@@ -65,11 +65,11 @@ var frozenPackage = []byte(`
                 }
             ],
             "_attachments": {
-                "%5Fweirdname.txt": {
+                "^_weirdname.txt": {
                     "content_type": "audio/mpeg",
                     "data": "YSBmaWxlIHdpdGggYSBzdHJhbmdlIG5hbWU="
                 },
-                "%EC%98%81%EC%83%81.jpg": {
+                "영상.jpg": {
                     "content_type": "audio/mpeg",
                     "data": "YSBLb3JlYW4gZmlsZW5hbWU="
                 },
@@ -142,7 +142,7 @@ var frozenPackage = []byte(`
                 }
             ],
             "_attachments": {
-                "%24main.css": {
+                "$main.css": {
                     "content_type": "text/css",
                     "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
                 },

--- a/test/theme_test.go
+++ b/test/theme_test.go
@@ -67,7 +67,7 @@ var frozenTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "%24main.css": {
+        "$main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }
@@ -174,7 +174,7 @@ var frozenExistingTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "%24main.css": {
+        "$main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }
@@ -245,7 +245,7 @@ var frozenMergedTheme = []byte(`
             "content_type": "text/plain",
             "data": "VGVzdCB0ZXh0IGZpbGU="
         },
-        "%24main.css": {
+        "$main.css": {
             "content_type": "text/css",
             "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
         }


### PR DESCRIPTION
I decided URL escaping was overkill, in large part because it would actually
make accessing filenames as paths (i.e.  directly from CouchDB) very
difficult, as everything would have to be double escaped.  Further, I
realized that I had already been using non-ASCII filenames successfully with
PouchDB, so any fears of future compatibility were probably overblown.