### PR TITLE
Revert to standard Base64 URL encoding

### DIFF
--- a/id.go
+++ b/id.go
@@ -16,7 +16,7 @@ var validDocIDTypes = map[string]struct{}{
 }
 
 func validateDocID(id string) error {
-	parts := strings.Split(id, "-")
+	parts := strings.SplitN(id, "-", 2)
 	if len(parts) != 2 {
 		return errors.New("invalid DocID format")
 	}

--- a/id_test.go
+++ b/id_test.go
@@ -33,6 +33,10 @@ func TestValidateDocID(t *testing.T) {
 			name: "valid",
 			id:   "deck-0123456789",
 		},
+		{
+			name: "multiple dashes",
+			id:   "deck--v4-v4",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,8 +4,4 @@ import (
 	"encoding/base64"
 )
 
-// We need a URL-safe encoding, but '-' has a special meaning in FB doc IDs, so
-// we use '=' instead (which is available since we don't use padding)
-const b64alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789=_"
-
-var b64encoder = base64.NewEncoding(b64alphabet).WithPadding(base64.NoPadding)
+var b64encoder = base64.URLEncoding.WithPadding(base64.NoPadding)


### PR DESCRIPTION
I realized I never have more than one significant '-' char, so there's no
reason to use a non-standard encoding.